### PR TITLE
CD GC Command Fix

### DIFF
--- a/.github/workflows/do-docker-publish.action.yml
+++ b/.github/workflows/do-docker-publish.action.yml
@@ -106,4 +106,4 @@ jobs:
         run: doctl registry login --expiry-seconds 600
 
       - name: Run Garbage Collection on the Repo
-        run: doctl registry gc start
+        run: doctl registry gc start --force true


### PR DESCRIPTION
Needed to add the `--force` arg to the GC collection on the Digitalocean container registry.