### PR TITLE
Action: Fix Detached Head Error

### DIFF
--- a/.github/workflows/ci.action.yml
+++ b/.github/workflows/ci.action.yml
@@ -37,6 +37,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
           node-version: 14
       - name: Update Lock File
         run: node common/scripts/install-run-rush.js update


### PR DESCRIPTION
Was getting an error due to the `checkout` action pulling the changes in a detached head mode so push to remote was not possible.

https://github.com/EndBug/add-and-commit#working-with-prs