### PR TITLE
Redis: Update Error Fix

### DIFF
--- a/apps/redis-sdk/src/client.ts
+++ b/apps/redis-sdk/src/client.ts
@@ -22,7 +22,7 @@ export class FullClient {
 			if (!this._connected) {
 				await this.connect();
 			}
-			await this.clearEntry(key);
+			await this.clearEntryIfExistsAlready(key);
 			await this._client.set(
 				key,
 				'$',
@@ -43,7 +43,7 @@ export class FullClient {
 			if (!this._connected) {
 				await this.connect();
 			}
-			await this.clearEntry(key);
+			await this.clearEntryIfExistsAlready(key);
 			await this._client.set(
 				key,
 				'$',
@@ -58,9 +58,13 @@ export class FullClient {
 		}
 	}
 
-	async clearEntry(key: string) {
+	async clearEntryIfExistsAlready(key: string) {
 		try {
-			await this._client.clear(key);
+			const entry = await this._client.get(key, '$');
+			if (entry == null || entry === '') {
+				return;
+			}
+			await this._client.clear(key, '$');
 		} catch (err) {
 			console.error(err);
 		}

--- a/apps/redis-sdk/src/client.ts
+++ b/apps/redis-sdk/src/client.ts
@@ -67,6 +67,7 @@ export class FullClient {
 			await this._client.clear(key, '$');
 		} catch (err) {
 			console.error(err);
+			return;
 		}
 	}
 

--- a/apps/redis-sdk/src/readonly-client.ts
+++ b/apps/redis-sdk/src/readonly-client.ts
@@ -33,6 +33,9 @@ export class ReadOnlyClient {
 				await this.connect();
 			}
 			const providers = await this._client.get(config.serviceProvidersPath);
+			if (providers == null || providers === '') {
+				throw Error('No records found');
+			}
 			const { records } = JSON.parse(providers) as {
 				records: ServiceProvider[];
 			};
@@ -49,8 +52,11 @@ export class ReadOnlyClient {
 			if (!this._connected) {
 				await this.connect();
 			}
-			const providers = await this._client.get(config.movieCatalogPath);
-			const { records } = JSON.parse(providers) as {
+			const movies = await this._client.get(config.movieCatalogPath);
+			if (movies == null || movies === '') {
+				throw Error('No records found');
+			}
+			const { records } = JSON.parse(movies) as {
 				records: MovieRecord[];
 			};
 			return records;


### PR DESCRIPTION
# Issue

Created a bug fix for the issue where the records where being concatenated, which was causing a-lot of duplicates. However, the clear command was throwing an error if the key did not exist.

# Fix

Added a check before executing the clear command to ensure that the record exists. If it does then clear it if not skip ahead.